### PR TITLE
Minor fix to obtainCollectionVersion

### DIFF
--- a/lib/util/sfCacheTaggingToolkit.class.php
+++ b/lib/util/sfCacheTaggingToolkit.class.php
@@ -284,6 +284,9 @@
       if (null === $collectionVersion)
       {
         $collectionVersion = self::generateVersion();
+        // Set the generated version in the cache so that subsequent calls to 
+        // obtainCollectionVersion return a consistent value
+        self::getTaggingCache()->setTag($collectionVersionName, $collectionVersion);
       }
 
       return $collectionVersion;


### PR DESCRIPTION
There was a race condition were multiple calls to sfCacheTaggingToolkit::obtainCollectionVersion for an unset collection tag would return different results.  The fix initialises and persists the collection version to the cache so that subsequent requests are consistent.
